### PR TITLE
Configuartion property kafkaclient -> consumer -> autoCommitIntervalM…

### DIFF
--- a/bootique-kafka-client/src/main/java/io/bootique/kafka/client/consumer/ConsumerConfig.java
+++ b/bootique-kafka-client/src/main/java/io/bootique/kafka/client/consumer/ConsumerConfig.java
@@ -20,7 +20,7 @@ public class ConsumerConfig<K, V> {
     private Deserializer<V> valueDeserializer;
     private String group;
     private Boolean autoCommit;
-    private Long autoCommitIntervalMs;
+    private Integer autoCommitIntervalMs;
     private Integer sessionTimeoutMs;
     private BootstrapServers bootstrapServers;
 
@@ -61,7 +61,7 @@ public class ConsumerConfig<K, V> {
         return autoCommit;
     }
 
-    public Long getAutoCommitIntervalMs() {
+    public Integer getAutoCommitIntervalMs() {
         return autoCommitIntervalMs;
     }
 
@@ -91,7 +91,7 @@ public class ConsumerConfig<K, V> {
             return this;
         }
 
-        public Builder<K, V> autoCommitIntervalMs(long ms) {
+        public Builder<K, V> autoCommitIntervalMs(int ms) {
             config.autoCommitIntervalMs = ms;
             return this;
         }

--- a/bootique-kafka-client/src/main/java/io/bootique/kafka/client/consumer/ConsumerFactory.java
+++ b/bootique-kafka-client/src/main/java/io/bootique/kafka/client/consumer/ConsumerFactory.java
@@ -34,12 +34,12 @@ public class ConsumerFactory {
 
     private String defaultGroup;
     private boolean autoCommit;
-    private long autoCommitIntervalMs;
+    private int autoCommitIntervalMs;
     private int sessionTimeoutMs;
 
     public ConsumerFactory() {
         this.autoCommit = true;
-        this.autoCommitIntervalMs = 1000l;
+        this.autoCommitIntervalMs = 1000;
         this.sessionTimeoutMs = 30000;
     }
 
@@ -54,7 +54,7 @@ public class ConsumerFactory {
     }
 
     @BQConfigProperty
-    public void setAutoCommitIntervalMs(long autoCommitIntervalMs) {
+    public void setAutoCommitIntervalMs(int autoCommitIntervalMs) {
         this.autoCommitIntervalMs = autoCommitIntervalMs;
     }
 


### PR DESCRIPTION
Configuration property kafkaclient -> consumer -> autoCommitIntervalMs must be integer, not long, because org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG is defined as INT (for long type exception occurs "throw new ConfigException(name, value, "Expected value to be a 32-bit integer, but it was a long");"